### PR TITLE
Changes AnsibleAWSError to ClientError

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -756,7 +756,7 @@ def main():
                                        resource='lambda'
                                        ))
         client = boto3_conn(module, **aws_connect_kwargs)
-    except AnsibleAWSError, e:
+    except ClientError, e:
         module.fail_json(msg="Can't authorize connection - {0}".format(e))
 
     invocations = {

--- a/lambda_facts.py
+++ b/lambda_facts.py
@@ -293,7 +293,7 @@ def main():
                                        resource='lambda'
                                        ))
         client = boto3_conn(module, **aws_connect_kwargs)
-    except AnsibleAWSError, e:
+    except ClientError, e:
         module.fail_json(msg="Can't authorize connection - {0}".format(e))
 
     invocations = {


### PR DESCRIPTION
- the library throws errors if these paths are executed because this
  Typed error doesn't exist.