### PR TITLE
fix document for lambda memory option

### DIFF
--- a/docsite/htmlout/lambda_module.html
+++ b/docsite/htmlout/lambda_module.html
@@ -544,11 +544,11 @@
     <td>The function within your code that Lambda calls to begin execution.</td>
 </tr>
         <tr>
-<td>memory</td>
+<td>memory_size</td>
 <td>no</td>
 <td></td>
     <td><ul></ul></td>
-    <td>The amount of memory, in MB, your Lambda function is given. Lambda uses this memory size to infer the amount of CPU and memory allocated to your function. Your function use-case determines your CPU and memory requirements. For example, a database operation might need less memory compared to an image processing function. The default value is 128 MB. The value must be a multiple of 64 MB.</td>
+    <td>The amount of memory_size, in MB, your Lambda function is given. Lambda uses this memory size to infer the amount of CPU and memory allocated to your function. Your function use-case determines your CPU and memory requirements. For example, a database operation might need less memory compared to an image processing function. The default value is 128 MB. The value must be a multiple of 64 MB.</td>
 </tr>
         <tr>
 <td>name</td>

--- a/modules/lambda.py
+++ b/modules/lambda.py
@@ -70,9 +70,9 @@ options:
       - The function execution time at which Lambda should terminate the function. Because the execution time has cost 
         implications, we recommend you set this value based on your expected execution time. The default is 3 seconds.
     required: false
-  memory:
+  memory_size:
     description:
-      - The amount of memory, in MB, your Lambda function is given. Lambda uses this memory size to infer the amount of 
+      - The amount of memory_size, in MB, your Lambda function is given. Lambda uses this memory size to infer the amount of 
         CPU and memory allocated to your function. Your function use-case determines your CPU and memory requirements. 
         For example, a database operation might need less memory compared to an image processing function. The default 
         value is 128 MB. The value must be a multiple of 64 MB.


### PR DESCRIPTION
memory to memory_size option

### YAML
- name: New Lambda Function                                                                        
  lambda:                                                                                          
    state: present                                                                                 
    type: code                                                                                     
    function_name: "{{LAMBDA.NAME}}"                                                               
    runtime: "{{LAMBDA.RUNTIME}}"                                                                  
    code:                                                                                          
      s3_bucket: "{{S3.BUCKET}}"                                                                   
      s3_key: "{{S3.DEST}}"                                                                        
    timeout: "{{LAMBDA.TIMEOUT}}"                                                                  
    handler: "{{LAMBDA.HANDLER}}"                                                                  
    role: "{{LAMBDA.ROLE}}"                                                                        
    description: "{{LAMBDA.DESCRIPTION}}"                                                          
    **memory**: 256                             

#### FAIL(memory)
fatal: [localhost]: FAILED! => 
{
  "changed": false,
  "failed": true,
  "invocation": {
    "module_args": {
      "code": {
        "s3_bucket": "d-nexts-tv-deploy",
        "s3_key": "lambda/ccc.zip"
      },
      "description": "CCC lambda function",
      "function_name": "ccc",
      "handler": "main.lambda_handler",
      "memory": 256,
      "publish": true,
      "role": "arn:aws:iam::XXXXXXXXXXXXX:role/vsapi-nexts-tv_lambda",
      "runtime": "python2.7",
      "state": "present",
      "timeout": "60",
      "type": "code"
    },
    "module_name": "lambda"
  },
  **"msg": "unsupported parameter for module: memory"**
}
