### PR TITLE
[lambda_policy] Updated documentation

### DIFF
--- a/docsite/htmlout/lambda_policy_module.html
+++ b/docsite/htmlout/lambda_policy_module.html
@@ -53,7 +53,7 @@
   
     <link rel="top" title="Ansible Documentation" href="index.html"/>
         <link rel="up" title="All Modules" href="list_of_all_modules.html"/>
-        <link rel="next" title="raw - Executes a low-down and dirty SSH command" href="raw_module.html"/>
+        <link rel="next" title="layman - Manage Gentoo overlays" href="layman_module.html"/>
         <link rel="prev" title="lambda_invoke - Invokes an AWS Lambda function" href="lambda_invoke_module.html"/> 
 
   <script src="//cdnjs.cloudflare.com/ajax/libs/modernizr/2.6.2/modernizr.min.js"></script>
@@ -125,8 +125,9 @@
 <li class="toctree-l2"><a class="reference internal" href="intro_patterns.html">Patterns</a></li>
 <li class="toctree-l2"><a class="reference internal" href="intro_adhoc.html">Introduction To Ad-Hoc Commands</a></li>
 <li class="toctree-l2"><a class="reference internal" href="intro_configuration.html">Configuration file</a></li>
-<li class="toctree-l2"><a class="reference internal" href="intro_bsd.html">BSD support</a></li>
+<li class="toctree-l2"><a class="reference internal" href="intro_bsd.html">BSD Support</a></li>
 <li class="toctree-l2"><a class="reference internal" href="intro_windows.html">Windows Support</a></li>
+<li class="toctree-l2"><a class="reference internal" href="intro_networking.html">Networking Support</a></li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="quickstart.html">Quickstart Video</a></li>
@@ -147,14 +148,17 @@
 <li class="toctree-l2"><a class="reference internal" href="playbooks_acceleration.html">Accelerated Mode</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_async.html">Asynchronous Actions and Polling</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_checkmode.html">Check Mode (&#8220;Dry Run&#8221;)</a></li>
+<li class="toctree-l2"><a class="reference internal" href="playbooks_debugger.html">Playbook Debugger</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_delegation.html">Delegation, Rolling Updates, and Local Actions</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_environment.html">Setting the Environment (and Working With Proxies)</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_error_handling.html">Error Handling In Playbooks</a></li>
+<li class="toctree-l2"><a class="reference internal" href="playbooks_advanced_syntax.html">Advanced Syntax</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_lookups.html">Using Lookups</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_prompts.html">Prompts</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_tags.html">Tags</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_vault.html">Vault</a></li>
 <li class="toctree-l2"><a class="reference internal" href="playbooks_startnstep.html">Start and Step</a></li>
+<li class="toctree-l2"><a class="reference internal" href="playbooks_directives.html">Directives Glossary</a></li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="modules.html">About Modules</a><ul>
@@ -167,16 +171,32 @@
 <li class="toctree-l1 current"><a class="reference internal" href="modules_by_category.html">Module Index</a><ul class="current">
 <li class="toctree-l2 current"><a class="reference internal" href="list_of_all_modules.html">All Modules</a></li>
 <li class="toctree-l2 current"><a class="reference internal" href="list_of_cloud_modules.html">Cloud Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_clustering_modules.html">Clustering Modules</a></li>
 <li class="toctree-l2"><a class="reference internal" href="list_of_commands_modules.html">Commands Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_database_modules.html">Database Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_files_modules.html">Files Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_inventory_modules.html">Inventory Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_messaging_modules.html">Messaging Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_monitoring_modules.html">Monitoring Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_network_modules.html">Network Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_notification_modules.html">Notification Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_packaging_modules.html">Packaging Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_source_control_modules.html">Source Control Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_system_modules.html">System Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_utilities_modules.html">Utilities Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_web_infrastructure_modules.html">Web Infrastructure Modules</a></li>
+<li class="toctree-l2"><a class="reference internal" href="list_of_windows_modules.html">Windows Modules</a></li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="guides.html">Detailed Guides</a><ul>
 <li class="toctree-l2"><a class="reference internal" href="guide_aws.html">Amazon Web Services Guide</a></li>
+<li class="toctree-l2"><a class="reference internal" href="guide_azure.html">Getting Started with Azure</a></li>
 <li class="toctree-l2"><a class="reference internal" href="guide_rax.html">Rackspace Cloud Guide</a></li>
 <li class="toctree-l2"><a class="reference internal" href="guide_gce.html">Google Cloud Platform Guide</a></li>
 <li class="toctree-l2"><a class="reference internal" href="guide_cloudstack.html">CloudStack Cloud Guide</a></li>
 <li class="toctree-l2"><a class="reference internal" href="guide_vagrant.html">Using Vagrant and Ansible</a></li>
 <li class="toctree-l2"><a class="reference internal" href="guide_rolling_upgrade.html">Continuous Delivery and Rolling Upgrades</a></li>
+<li class="toctree-l2"><a class="reference internal" href="guide_docker.html">Getting Started with Docker</a></li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="developing.html">Developer Information</a><ul>
@@ -184,6 +204,7 @@
 <li class="toctree-l2"><a class="reference internal" href="developing_inventory.html">Developing Dynamic Inventory Sources</a></li>
 <li class="toctree-l2"><a class="reference internal" href="developing_modules.html">Developing Modules</a></li>
 <li class="toctree-l2"><a class="reference internal" href="developing_plugins.html">Developing Plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="developing_core.html">Developing the Ansible Core Engine</a></li>
 <li class="toctree-l2"><a class="reference internal" href="developing_test_pr.html">Helping Testing PRs</a></li>
 <li class="toctree-l2"><a class="reference internal" href="developing_releases.html">Releases</a></li>
 </ul>
@@ -193,6 +214,8 @@
 <li class="toctree-l2"><a class="reference internal" href="community.html#ansible-users">Ansible Users</a></li>
 <li class="toctree-l2"><a class="reference internal" href="community.html#for-current-and-prospective-developers">For Current and Prospective Developers</a></li>
 <li class="toctree-l2"><a class="reference internal" href="community.html#other-topics">Other Topics</a></li>
+<li class="toctree-l2"><a class="reference internal" href="community.html#community-code-of-conduct">Community Code of Conduct</a></li>
+<li class="toctree-l2"><a class="reference internal" href="community.html#contributors-license-agreement">Contributors License Agreement</a></li>
 </ul>
 </li>
 <li class="toctree-l1"><a class="reference internal" href="galaxy.html">Ansible Galaxy</a><ul>
@@ -233,74 +256,39 @@
 <li class="toctree-l2"><a class="reference internal" href="faq.html#is-there-a-web-interface-rest-api-etc">Is there a web interface / REST API / etc?</a></li>
 <li class="toctree-l2"><a class="reference internal" href="faq.html#how-do-i-submit-a-change-to-the-documentation">How do I submit a change to the documentation?</a></li>
 <li class="toctree-l2"><a class="reference internal" href="faq.html#how-do-i-keep-secret-data-in-my-playbook">How do I keep secret data in my playbook?</a></li>
+<li class="toctree-l2"><a class="reference internal" href="faq.html#when-should-i-use-also-how-to-interpolate-variables-or-dynamic-variable-names">When should I use {{ }}? Also, how to interpolate variables or dynamic variable names</a></li>
 <li class="toctree-l2"><a class="reference internal" href="faq.html#i-don-t-see-my-question-here">I don&#8217;t see my question here</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="glossary.html">Glossary</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#action">Action</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#ad-hoc">Ad Hoc</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#async">Async</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#callback-plugin">Callback Plugin</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#check-mode">Check Mode</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#connection-type-connection-plugin">Connection Type, Connection Plugin</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#conditionals">Conditionals</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#diff-mode">Diff Mode</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#facts">Facts</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#filter-plugin">Filter Plugin</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#forks">Forks</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#gather-facts-boolean">Gather Facts (Boolean)</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#globbing">Globbing</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#group">Group</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#group-vars">Group Vars</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#handlers">Handlers</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#host">Host</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#host-specifier">Host Specifier</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#host-vars">Host Vars</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#idempotency">Idempotency</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#includes">Includes</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#inventory">Inventory</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#inventory-script">Inventory Script</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#jinja2">Jinja2</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#json">JSON</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#lazy-evaluation">Lazy Evaluation</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#library">Library</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#limit-groups">Limit Groups</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#local-action">Local Action</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#local-connection">Local Connection</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#lookup-plugin">Lookup Plugin</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#loops">Loops</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#modules">Modules</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#multi-tier">Multi-Tier</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#notify">Notify</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#orchestration">Orchestration</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#paramiko">paramiko</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#playbooks">Playbooks</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#plays">Plays</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#pull-mode">Pull Mode</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#push-mode">Push Mode</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#register-variable">Register Variable</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#resource-model">Resource Model</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#roles">Roles</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#rolling-update">Rolling Update</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#runner">Runner</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#serial">Serial</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#sudo">Sudo</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#ssh-native">SSH (Native)</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#tags">Tags</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#tasks">Tasks</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#templates">Templates</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#transport">Transport</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#when">When</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#van-halen">Van Halen</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#vars-variables">Vars (Variables)</a></li>
-<li class="toctree-l2"><a class="reference internal" href="glossary.html#yaml">YAML</a></li>
-</ul>
-</li>
+<li class="toctree-l1"><a class="reference internal" href="glossary.html">Glossary</a></li>
 <li class="toctree-l1"><a class="reference internal" href="YAMLSyntax.html">YAML Syntax</a><ul>
 <li class="toctree-l2"><a class="reference internal" href="YAMLSyntax.html#yaml-basics">YAML Basics</a></li>
 <li class="toctree-l2"><a class="reference internal" href="YAMLSyntax.html#gotchas">Gotchas</a></li>
 </ul>
 </li>
+<li class="toctree-l1"><a class="reference internal" href="porting_guide_2.0.html">Porting Guide</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#playbook">Playbook</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#deprecated">Deprecated</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#other-caveats">Other caveats</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="porting_guide_2.0.html#porting-plugins">Porting plugins</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#lookup-plugins">Lookup plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#connection-plugins">Connection plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#action-plugins">Action plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#callback-plugins">Callback plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#id1">Connection plugins</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="porting_guide_2.0.html#hybrid-plugins">Hybrid plugins</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#id2">Lookup plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#id3">Connection plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#id4">Action plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#id5">Callback plugins</a></li>
+<li class="toctree-l2"><a class="reference internal" href="porting_guide_2.0.html#id6">Connection plugins</a></li>
+</ul>
+</li>
+<li class="toctree-l1"><a class="reference internal" href="porting_guide_2.0.html#porting-custom-scripts">Porting custom scripts</a></li>
 </ul>
 
         
@@ -355,12 +343,12 @@
   <div class="section" id="lambda-policy-creates-updates-or-deletes-aws-lambda-policy-statements">
 <span id="lambda-policy"></span><h1>lambda_policy - Creates, updates or deletes AWS Lambda policy statements.<a class="headerlink" href="#lambda-policy-creates-updates-or-deletes-aws-lambda-policy-statements" title="Permalink to this headline">¶</a></h1>
 <div class="versionadded">
-<p><span class="versionmodified">New in version 2.1.</span></p>
+<p><span class="versionmodified">New in version 2.2.</span></p>
 </div>
 <div class="contents local topic" id="contents">
 <ul class="simple">
 <li><a class="reference internal" href="#synopsis" id="id1">Synopsis</a></li>
-<li><a class="reference internal" href="#requirements" id="id2">Requirements</a></li>
+<li><a class="reference internal" href="#requirements-on-host-that-executes-module" id="id2">Requirements (on host that executes module)</a></li>
 <li><a class="reference internal" href="#options" id="id3">Options</a></li>
 <li><a class="reference internal" href="#examples" id="id4">Examples</a></li>
 <li><a class="reference internal" href="#return-values" id="id5">Return Values</a></li>
@@ -370,10 +358,10 @@
 </div>
 <div class="section" id="synopsis">
 <h2><a class="toc-backref" href="#id1">Synopsis</a><a class="headerlink" href="#synopsis" title="Permalink to this headline">¶</a></h2>
-<p>This module allows the management of AWS Lambda policy statements. It is idempotent and supports &#8220;Check&#8221; mode.  Use module <a class="reference internal" href="lambda_module.html#lambda"><span>lambda</span></a> to manage the lambda function itself, <a class="reference internal" href="lambda_alias_module.html#lambda-alias"><span>lambda_alias</span></a> to manage function aliases, <a class="reference internal" href="lambda_event_module.html#lambda-event"><span>lambda_event</span></a> to manage event source mappings such as Kinesis streams, <a class="reference internal" href="lambda_invoke_module.html#lambda-invoke"><span>lambda_invoke</span></a> to execute a lambda function and <a class="reference internal" href="lambda_facts_module.html#lambda-facts"><span>lambda_facts</span></a> to gather facts relating to one or more lambda functions.</p>
+<p>This module allows the management of AWS Lambda policy statements. It is idempotent and supports &#8220;Check&#8221; mode.  Use module <a class="reference internal" href="lambda_module.html#lambda"><span class="std std-ref">lambda</span></a> to manage the lambda function itself, <a class="reference internal" href="lambda_alias_module.html#lambda-alias"><span class="std std-ref">lambda_alias</span></a> to manage function aliases, <a class="reference internal" href="lambda_event_module.html#lambda-event"><span class="std std-ref">lambda_event</span></a> to manage event source mappings such as Kinesis streams, <a class="reference internal" href="lambda_invoke_module.html#lambda-invoke"><span class="std std-ref">lambda_invoke</span></a> to execute a lambda function and <a class="reference internal" href="lambda_facts_module.html#lambda-facts"><span class="std std-ref">lambda_facts</span></a> to gather facts relating to one or more lambda functions.</p>
 </div>
-<div class="section" id="requirements">
-<h2><a class="toc-backref" href="#id2">Requirements</a><a class="headerlink" href="#requirements" title="Permalink to this headline">¶</a></h2>
+<div class="section" id="requirements-on-host-that-executes-module">
+<h2><a class="toc-backref" href="#id2">Requirements (on host that executes module)</a><a class="headerlink" href="#requirements-on-host-that-executes-module" title="Permalink to this headline">¶</a></h2>
 <blockquote>
 <div><ul class="simple">
 <li>boto</li>
@@ -400,7 +388,7 @@
     <td><div>The AWS Lambda action you want to allow in this statement. Each Lambda action is a string starting with lambda: followed by the API name (see Operations ). For example, lambda:CreateFunction . You can use wildcard (lambda:* ) to grant permission for all AWS Lambda actions.</div></td></tr>
         <tr>
 <td>alias<br/><div style="font-size: small;"></div></td>
-<td>yes</td>
+<td>no</td>
 <td></td>
     <td><ul></ul></td>
     <td><div>Name of the function alias. Mutually exclusive with <code>version</code>.</div></td></tr>
@@ -473,7 +461,7 @@
 <td>yes</td>
 <td>present</td>
     <td><ul><li>present</li><li>absent</li></ul></td>
-    <td><div>Describes the desired state and defaults to "present".</div></td></tr>
+    <td><div>Describes the desired state.</div></td></tr>
         <tr>
 <td>statement_id<br/><div style="font-size: small;"></div></td>
 <td>yes</td>
@@ -498,7 +486,7 @@
 <div class="section" id="examples">
 <h2><a class="toc-backref" href="#id4">Examples</a><a class="headerlink" href="#examples" title="Permalink to this headline">¶</a></h2>
 <blockquote>
-<div><div class="highlight-YAML"><div class="highlight"><pre><span></span><span class="nn">---</span>
+<div><div class="highlight-yaml"><div class="highlight"><pre><span></span><span class="nn">---</span>
 <span class="p p-Indicator">-</span> <span class="l l-Scalar l-Scalar-Plain">hosts</span><span class="p p-Indicator">:</span> <span class="l l-Scalar l-Scalar-Plain">localhost</span>
   <span class="l l-Scalar l-Scalar-Plain">gather_facts</span><span class="p p-Indicator">:</span> <span class="l l-Scalar l-Scalar-Plain">no</span>
   <span class="l l-Scalar l-Scalar-Plain">vars</span><span class="p p-Indicator">:</span>
@@ -523,7 +511,7 @@
 </div>
 <div class="section" id="return-values">
 <h2><a class="toc-backref" href="#id5">Return Values</a><a class="headerlink" href="#return-values" title="Permalink to this headline">¶</a></h2>
-<p>Common return values are documented here <a class="reference internal" href="common_return_values.html"><em>Common Return Values</em></a>, the following are the fields unique to this module:</p>
+<p>Common return values are documented here <a class="reference internal" href="common_return_values.html"><span class="doc">Common Return Values</span></a>, the following are the fields unique to this module:</p>
 <table border=1 cellpadding=4>
 <tr>
 <th class="head">name</th>
@@ -560,8 +548,8 @@
 </div>
 <div class="section" id="this-is-an-extras-module">
 <h2><a class="toc-backref" href="#id7">This is an Extras Module</a><a class="headerlink" href="#this-is-an-extras-module" title="Permalink to this headline">¶</a></h2>
-<p>For more information on what this means please read <a class="reference internal" href="modules_extra.html"><em>Extras Modules</em></a></p>
-<p>For help in developing on modules, should you be so inclined, please read <a class="reference internal" href="community.html"><em>Community Information &amp; Contributing</em></a>, <a class="reference internal" href="developing_test_pr.html"><em>Helping Testing PRs</em></a> and <a class="reference internal" href="developing_modules.html"><em>Developing Modules</em></a>.</p>
+<p>For more information on what this means please read <a class="reference internal" href="modules_extra.html"><span class="doc">Extras Modules</span></a></p>
+<p>For help in developing on modules, should you be so inclined, please read <a class="reference internal" href="community.html"><span class="doc">Community Information &amp; Contributing</span></a>, <a class="reference internal" href="developing_test_pr.html"><span class="doc">Helping Testing PRs</span></a> and <a class="reference internal" href="developing_modules.html"><span class="doc">Developing Modules</span></a>.</p>
 </div>
 </div>
 
@@ -572,7 +560,7 @@
   
     <div class="rst-footer-buttons">
       
-        <a href="raw_module.html" class="btn btn-neutral float-right" title="raw - Executes a low-down and dirty SSH command"/>Next <span class="icon icon-circle-arrow-right"></span></a>
+        <a href="layman_module.html" class="btn btn-neutral float-right" title="layman - Manage Gentoo overlays"/>Next <span class="icon icon-circle-arrow-right"></span></a>
       
       
         <a href="lambda_invoke_module.html" class="btn btn-neutral" title="lambda_invoke - Invokes an AWS Lambda function"><span class="icon icon-circle-arrow-left"></span> Previous</a>
@@ -582,13 +570,23 @@
 
   <hr/>
 
+<script type="text/javascript">
+  (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+  (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+  e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+  })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+
+  _st('install','yABGvz2N8PwcwBxyfzUc','2.0.0');
+</script>
+
   <p>
-  &copy; Copyright 2016 <a href="http://ansible.com">Ansible, Inc.</a>.
-    Last updated on Apr 19, 2016.
+  Copyright © 2016 Red Hat, Inc.
+  <br>
+    Last updated on Jun 16, 2016.
   </p>
-
+<p>
 Ansible docs are generated from <a href="https://github.com/ansible/ansible">GitHub sources</A> using <A HREF="http://sphinx-doc.org/">Sphinx</A> using a theme provided by <a href="http://readthedocs.org">Read the Docs</a>. . Module documentation is not edited directly, but is generated from the source code for the modules.  To submit an update to module docs, edit the 'DOCUMENTATION' metadata in the <A HREF="https://github.com/ansible/ansible-modules-core">core</A> and <A HREF="https://github.com/ansible/ansible-modules-extras">extras</A> modules source repositories. 
-
+</p>
 </footer>
         </div>
       </div>

--- a/modules/lambda_policy.py
+++ b/modules/lambda_policy.py
@@ -65,7 +65,7 @@ options:
   alias:
     description:
       - Name of the function alias. Mutually exclusive with C(version).
-    required: true
+    required: false
 
   version:
     description:


### PR DESCRIPTION
Specifying `version` or `alias` is optional in lambda_policy. (which is what you use if don't define an alias for your lambda function and don't want to specify version [1])
Updating documentation to reflect that.

Also run `make webdocs` and updated `lambda_policy_module.html`.
Not sure if version should have been bumped I left it at `2.2` for this change.

[1]: Note that, at least in the UI, version also shows `$LATEST` so I am not sure if limiting version to `int` is correct. However, I don't think it's a big deal as if we are not interested in the version we can omit both `version` and `alias` which is what this PR documents.